### PR TITLE
Add authorization levels to users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,11 @@ gem 'bcrypt', '~> 3.1.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 
+# Cancancan gem
+gem 'cancancan', '>= 3.2.0'
+
+
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    cancancan (3.3.0)
     capybara (3.35.3)
       addressable
       mini_mime (>= 0.1.3)
@@ -204,6 +205,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
   byebug
+  cancancan (>= 3.2.0)
   capybara (>= 3.26)
   jbuilder (~> 2.7)
   listen (~> 3.3)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the passed in user here. For example:
+    #
+    #   user ||= User.new # guest user (not logged in)
+    #   if user.admin?
+    #     can :manage, :all
+    #   else
+    #     can :read, :all
+    #   end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+  end
+end

--- a/db/migrate/20210816190623_add_auth_levels_to_users.rb
+++ b/db/migrate/20210816190623_add_auth_levels_to_users.rb
@@ -1,0 +1,6 @@
+class AddAuthLevelsToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :manager, :boolean
+    add_column :users, :admin, :boolean
+  end
+end

--- a/db/migrate/20210816191339_change_auth_default.rb
+++ b/db/migrate/20210816191339_change_auth_default.rb
@@ -1,0 +1,6 @@
+class ChangeAuthDefault < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :users, :manager, false
+    change_column_default :users, :admin, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_26_205120) do
+ActiveRecord::Schema.define(version: 2021_08_16_191339) do
 
   create_table "users", force: :cascade do |t|
     t.string "email"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 2021_05_26_205120) do
     t.string "title"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "manager", default: false
+    t.boolean "admin", default: false
   end
 
 end


### PR DESCRIPTION
### Cancancan Implementation:

- Add `cancancan` ruby gem
- create migration to add two new auth roles to `Users`: `manager` & `admin`
- alter previous migration so those new roles are set to `false` by default
- generate `cancan:ability` migration for future use