### PR TITLE
`nokogirl` keeps showing up in gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,8 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.7)
+    nokogiri (1.11.6-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.11.6-x86_64-linux)
       racc (~> 1.4)
     oauth2 (1.4.4)
@@ -249,6 +251,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Trying to fix issue with nokogirl gem that keeps showing up as a change to the `Gemfile.lock` file. Each time I switch to `main` branch, it shows up automatically. 