### PR TITLE
Remove Simple Form:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem 'active_model_serializers'
 # Fast Json API
 gem 'fast_jsonapi'
 
-
 # Google Oauth required gems
 # OmniAuth gem
 gem 'omniauth'
@@ -56,9 +55,6 @@ gem 'omniauth-google-oauth2'
 
 # Intuit Oauth gem
 gem 'omniauth-intuit-oauth2', '~> 0.2.0'
-
-# Form Formatting
-gem 'simple_form'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,9 +248,6 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
-    simple_form (5.1.0)
-      actionpack (>= 5.2)
-      activemodel (>= 5.2)
     spring (2.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -317,7 +314,6 @@ DEPENDENCIES
   rspec-rails
   sass-rails (>= 6)
   selenium-webdriver
-  simple_form
   spring
   sqlite3 (~> 1.4)
   turbolinks (~> 5)


### PR DESCRIPTION
### Remove Simple Form Gem

Since we are no longer using the rails front-end and because Simple Form was causing some minor errors when running tests, we can remove it.