### PR TITLE
Fix Session Destroy Authenticity Error:

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:destroy]
+
   def create
     auth = request.env["omniauth.auth"]
     @user = authenticate_with_omniauth(auth) if auth


### PR DESCRIPTION
### Fix Session Destroy Authenticity Error

Since removing the `skip_before_action :verify_authenticity_token` from `application_controller.rb` we need to re-add it for destroying a session. It is now in the Sessions Controller